### PR TITLE
Update how response exceptions are handled from http-client

### DIFF
--- a/src/Network/Bitcoin/Api/Internal.hs
+++ b/src/Network/Bitcoin/Api/Internal.hs
@@ -15,7 +15,7 @@ import qualified Network.Wreq              as W
 import qualified Network.Wreq.Session      as WS
 
 import qualified Control.Monad.Catch       as E
-import           Network.HTTP.Client       (HttpException (..))
+import           Network.HTTP.Client       (HttpException (..), HttpExceptionContent (..))
 
 import           Data.Aeson
 import qualified Data.HashMap.Strict       as HM

--- a/src/Network/Bitcoin/Api/Internal.hs
+++ b/src/Network/Bitcoin/Api/Internal.hs
@@ -15,7 +15,7 @@ import qualified Network.Wreq              as W
 import qualified Network.Wreq.Session      as WS
 
 import qualified Control.Monad.Catch       as E
-import           Network.HTTP.Client       (HttpException (..), HttpExceptionContent (..))
+import           Network.HTTP.Client       (HttpException (..), HttpExceptionContent (..), responseHeaders)
 
 import           Data.Aeson
 import qualified Data.HashMap.Strict       as HM
@@ -89,9 +89,9 @@ call client method params =
                 command
         case rE of
           Right r -> return (r ^. W.responseBody)
-          Left ex@(StatusCodeException _ hdrL _) ->
+          Left ex@(HttpExceptionRequest _ (StatusCodeException response _) ) ->
             throwNothing (hdrM >>= decode . BL.fromStrict)
-                where hdrM = lookup "X-Response-Body-Start" hdrL
+                where hdrM = lookup "X-Response-Body-Start" $ responseHeaders response
                       throwNothing = maybe (E.throwM (ex :: HttpException)) return
           Left ex -> E.throwM (ex :: HttpException)
 


### PR DESCRIPTION
http-client has had a significant (breaking) change, and this update aims to ensure the bitcoin-api library builds with the latest release of http-client, `http-client-0.5.7.1`. I am building this with stackage LTS 10.2, which also means this is being built by GHC 8.2.2. I have tested this update via a super simple demo - https://github.com/ketzacoatl/btc-monitor/blob/master/src/Main.hs - and it appears to be working. `stack test` fails as there is a test that uses `StatusCodeException` in `test/Network/Bitcoin/Api/TestUtil.hs`, though I only just now noticed that.

Thanks to @norfairKing for his support in figuring out this update, I would not have been able to put this together on my own.